### PR TITLE
Add 'do not declare sensitive = false' rules for `output` and `variable` blocks

### DIFF
--- a/codex/logic_code/outputs.md
+++ b/codex/logic_code/outputs.md
@@ -6,6 +6,8 @@
 
 ## `output` contains confidential data should declare `sensitive = true`
 
+## Do not declare `sensitive = false`
+
 ## A blank line should exist between 2 `output`s
 
 ## Dealing with Deprecated `output`s

--- a/codex/logic_code/variables.tf.md
+++ b/codex/logic_code/variables.tf.md
@@ -78,6 +78,8 @@ If `variable`'s `type` is `object` and contains one or more fields that would be
 
 ## Do not declare `nullable = true`
 
+## Do not declare `sensitive = false`
+
 ## `variable` with `sensitive = true` cannot have default value unless the default value represents turning off a feature, like `default = null` or `default = []`
 
 ## `default` value of a `variable`


### PR DESCRIPTION
Since `sensitive` is default to `false` it's meaningless to declare `sensitive = false` in `output` and `variable` blocks.